### PR TITLE
Replace nfs server with nfs v3 on Ubuntu Trusty

### DIFF
--- a/bin/create-all.sh
+++ b/bin/create-all.sh
@@ -142,6 +142,7 @@ else
   ${SCRIPT_DIR}/create-rc-w-esb.sh roxie 2 
 fi
 
+
 #------------------------------------------------
 # Create Esp pods and load balancer service
 #

--- a/bin/create-nfs.sh
+++ b/bin/create-nfs.sh
@@ -70,7 +70,7 @@ spec:
     spec:
       containers:
       - name: nfs-server
-        image: gcr.io/google-samples/nfs-server:1.1
+        image: hpccsystems/nfs-server:latest
         command:
           - /usr/local/bin/run_nfs.sh
         args:
@@ -159,6 +159,7 @@ fi
 create_rc_yaml
 
 
+sleep 20
 #------------------------------------------------
 # Create NFS server and its service 
 #

--- a/config-default-pv-template.yaml
+++ b/config-default-pv-template.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: config-default
+  labels:
+    config-type: default
 spec:
   capacity:
     storage: 1Gi

--- a/config-default-pvc.yaml
+++ b/config-default-pvc.yaml
@@ -8,3 +8,6 @@ spec:
   resources:
     requests:
       storage: 1Gi
+  selector:
+    matchLabels:
+      config-type: default

--- a/config-esp-pv-template.yaml
+++ b/config-esp-pv-template.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: config-esp
+  labels:
+    config-type: esp 
 spec:
   capacity:
     storage: 1Gi

--- a/config-esp-pvc.yaml
+++ b/config-esp-pvc.yaml
@@ -8,3 +8,6 @@ spec:
   resources:
     requests:
       storage: 1Gi
+  selector:
+    matchLabels:
+      config-type: esp

--- a/config-roxie-pv-template.yaml
+++ b/config-roxie-pv-template.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: config-roxie
+  labels:
+    config-type: roxie
 spec:
   capacity:
     storage: 1Gi

--- a/config-roxie-pvc.yaml
+++ b/config-roxie-pvc.yaml
@@ -8,3 +8,6 @@ spec:
   resources:
     requests:
       storage: 1Gi
+  selector:
+    matchLabels:
+      config-type: roxie

--- a/nfs-server-rc-template.yaml
+++ b/nfs-server-rc-template.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: nfs-server
-        image: gcr.io/google-samples/nfs-server:1.1
+        image: hpccsystems/nfs-server:latest
         command:
           - /usr/local/bin/run_nfs.sh
         args:

--- a/roxie-service-template.yaml
+++ b/roxie-service-template.yaml
@@ -10,6 +10,10 @@ spec:
       protocol: TCP
       port: 9876
       targetPort: 9876 
+    - name: dfs
+      protocol: TCP
+      port: 7100
+      targetPort: 7100
   selector: 
      app: roxie<INDEX>
   type: LoadBalancer


### PR DESCRIPTION
This fixed the problem of only first shared drive can be mounted by nfs
Also add label to PV to let PVC easy identify similar PV